### PR TITLE
Phase 2.5: Pattern Observability (Events + Notifications)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An autonomous trading system that starts with **paper trading** (no real money) 
 - Robust end-to-end pipeline: **Market data → Features → Strategies → Risk → Execution (paper) → Ledger → Reports**
 - Safety-first design: central Risk Engine + kill-switch control
 - Observability: Prometheus metrics + Grafana dashboards + daily EOD reports
+  - New: Pattern Observability (Phase 2.5) — counters/histograms and Loki logs; see docs: `docs/decisions/ADR-0012-pattern-observability.md` and `docs/RUNBOOK.md` → Pattern Observability.
 - Incremental development in **phases**, each with tests and documentation
 
 ## Tech Stack

--- a/config/grafana/provisioning/alerting/mtm-missing.yml
+++ b/config/grafana/provisioning/alerting/mtm-missing.yml
@@ -12,6 +12,9 @@ groups:
           - refId: A
             queryType: timeSeriesQuery
             datasourceUid: PBFA97CFB590B2093
+            relativeTimeRange:
+              from: 120
+              to: 0
             model:
               expr: absent(increase(mtm_tick_total[1m]))
               intervalMs: 60000
@@ -26,4 +29,3 @@ groups:
           severity: critical
         labels:
           app: paperbot
-

--- a/config/grafana/provisioning/alerting/mtm-missing.yml
+++ b/config/grafana/provisioning/alerting/mtm-missing.yml
@@ -1,0 +1,29 @@
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: paperbot-alerts
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: mtm-missing
+        title: MTM tick missing
+        condition: A
+        data:
+          - refId: A
+            queryType: timeSeriesQuery
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: absent(increase(mtm_tick_total[1m]))
+              intervalMs: 60000
+              maxDataPoints: 43200
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          severity: critical
+        labels:
+          app: paperbot
+

--- a/config/grafana/provisioning/alerting/patterns-min-activity.yml
+++ b/config/grafana/provisioning/alerting/patterns-min-activity.yml
@@ -1,0 +1,31 @@
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: paperbot-patterns
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: patterns-min-activity
+        title: No pattern detections (30m)
+        condition: A
+        data:
+          - refId: A
+            queryType: timeSeriesQuery
+            datasourceUid: PBFA97CFB590B2093
+            relativeTimeRange:
+              from: 2700
+              to: 0
+            model:
+              expr: sum(increase(pattern_detected_total[30m])) == 0
+              intervalMs: 60000
+              maxDataPoints: 43200
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 45m
+        annotations:
+            severity: warning
+        labels:
+            app: paperbot

--- a/config/grafana/provisioning/dashboards/paperbot-crypto.json
+++ b/config/grafana/provisioning/dashboards/paperbot-crypto.json
@@ -19,6 +19,8 @@
     {"title": "Orders submitted rate (5m)", "targets": [{"expr": "sum by (type,symbol) (rate(orders_submitted_by_market_total{market=\"crypto\"}[5m]))"}]},
     {"title": "Fills rate by liquidity (5m)", "targets": [{"expr": "sum by (liquidity,symbol) (rate(fills_by_market_total{market=\"crypto\"}[5m]))"}]},
     {"title": "Fees paid (1h)", "targets": [{"expr": "sum by (symbol) (increase(fees_paid_usd_total{market=\"crypto\"}[1h]))"}]},
-    {"title": "Equity (total)", "targets": [{"expr": "account_equity_usd{market=\"crypto\"}"}]}
+    {"title": "Equity (total)", "targets": [{"expr": "account_equity_usd{market=\"crypto\"}"}]},
+    {"title": "Logs (Loki) — Stream", "type": "logs", "datasource": "Loki", "targets": [{"query": "{app=\\\"paperbot\\\"}"}]},
+    {"title": "Logs (Loki) — Errors (5m)", "type": "stat", "datasource": "Loki", "targets": [{"query": "sum(count_over_time({app=\\\"paperbot\\\"} |= \\\"ERROR\\\" [5m]))"}]}
   ]
 }

--- a/config/grafana/provisioning/dashboards/paperbot-stocks.json
+++ b/config/grafana/provisioning/dashboards/paperbot-stocks.json
@@ -19,6 +19,8 @@
     {"title": "Orders submitted rate (5m)", "targets": [{"expr": "sum by (type,symbol) (rate(orders_submitted_by_market_total{market=\"stocks\"}[5m]))"}]},
     {"title": "Fills rate by liquidity (5m)", "targets": [{"expr": "sum by (liquidity,symbol) (rate(fills_by_market_total{market=\"stocks\"}[5m]))"}]},
     {"title": "Fees paid (1h)", "targets": [{"expr": "sum by (symbol) (increase(fees_paid_usd_total{market=\"stocks\"}[1h]))"}]},
-    {"title": "Equity (total)", "targets": [{"expr": "account_equity_usd{market=\"stocks\"}"}]}
+    {"title": "Equity (total)", "targets": [{"expr": "account_equity_usd{market=\"stocks\"}"}]},
+    {"title": "Logs (Loki) — Stream", "type": "logs", "datasource": "Loki", "targets": [{"query": "{app=\\\"paperbot\\\"}"}]},
+    {"title": "Logs (Loki) — Errors (5m)", "type": "stat", "datasource": "Loki", "targets": [{"query": "sum(count_over_time({app=\\\"paperbot\\\"} |= \\\"ERROR\\\" [5m]))"}]}
   ]
 }

--- a/config/grafana/provisioning/dashboards/paperbot.json
+++ b/config/grafana/provisioning/dashboards/paperbot.json
@@ -78,6 +78,68 @@
       "type": "stat"
     },
     {
+      "type": "row",
+      "title": "Patterns",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "id": 20
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 57 },
+      "id": 21,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true } },
+      "targets": [ { "expr": "sum by (pattern) (rate(pattern_detected_total[5m]))", "refId": "A", "legendFormat": "{{pattern}}" } ],
+      "title": "Pattern detections rate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 57 },
+      "id": 22,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true } },
+      "targets": [ { "expr": "sum by (pattern,side) (rate(pattern_intent_total[5m]))", "refId": "A", "legendFormat": "{{pattern}} {{side}}" } ],
+      "title": "Pattern intents rate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 65 },
+      "id": 23,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": true } },
+      "targets": [ { "expr": "histogram_quantile(0.5, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))", "refId": "A" } ],
+      "title": "Pattern→Intent latency P50 (s)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 65 },
+      "id": 24,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": true } },
+      "targets": [ { "expr": "histogram_quantile(0.95, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))", "refId": "A" } ],
+      "title": "Pattern→Intent latency P95 (s)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Loki",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 71 },
+      "id": 25,
+      "targets": [ { "query": "{app=\"paperbot\"} | json | event=\"pattern_detected\"" } ],
+      "title": "Logs — pattern_detected",
+      "type": "logs"
+    },
+    {
+      "datasource": "Loki",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 71 },
+      "id": 26,
+      "targets": [ { "query": "{app=\"paperbot\"} | json | event=\"pattern_intent\"" } ],
+      "title": "Logs — pattern_intent",
+      "type": "logs"
+    },
+    {
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {

--- a/config/grafana/provisioning/dashboards/paperbot.json
+++ b/config/grafana/provisioning/dashboards/paperbot.json
@@ -127,7 +127,7 @@
       "datasource": "Loki",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 71 },
       "id": 25,
-      "targets": [ { "query": "{app=\"paperbot\"} | json | event=\"pattern_detected\"" } ],
+      "targets": [ { "query": "{app=\"paperbot\"} |= \"pattern_detected\" " } ],
       "title": "Logs — pattern_detected",
       "type": "logs"
     },
@@ -135,7 +135,7 @@
       "datasource": "Loki",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 71 },
       "id": 26,
-      "targets": [ { "query": "{app=\"paperbot\"} | json | event=\"pattern_intent\"" } ],
+      "targets": [ { "query": "{app=\"paperbot\"} |= \"pattern_intent\" " } ],
       "title": "Logs — pattern_intent",
       "type": "logs"
     },

--- a/config/grafana/provisioning/datasources/loki.yml
+++ b/config/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true
+

--- a/config/loki/config.yml
+++ b/config/loki/config.yml
@@ -1,16 +1,22 @@
 auth_enabled: false
 server:
   http_listen_port: 3100
+
 common:
   path_prefix: /loki
-  storage:
-    filesystem:
-      chunks_directory: /loki/chunks
-      rules_directory: /loki/rules
   replication_factor: 1
   ring:
     kvstore:
       store: inmemory
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/boltdb-cache
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
 schema_config:
   configs:
     - from: 2020-10-15
@@ -20,6 +26,16 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+
+compactor:
+  working_directory: /loki/boltdb-cache
+
 ruler:
   alertmanager_url: http://localhost:9093
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
 
+limits_config:
+  allow_structured_metadata: false

--- a/config/loki/config.yml
+++ b/config/loki/config.yml
@@ -1,0 +1,25 @@
+auth_enabled: false
+server:
+  http_listen_port: 3100
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+schema_config:
+  configs:
+    - from: 2020-10-15
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+ruler:
+  alertmanager_url: http://localhost:9093
+

--- a/config/promtail/config.yml
+++ b/config/promtail/config.yml
@@ -1,0 +1,30 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker-logs
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: docker
+          app: paperbot
+          __path__: /var/lib/docker/containers/*/*.log
+    pipeline_stages:
+      - docker: {}
+      - match:
+          selector: '{app="paperbot"}'
+          stages:
+            - timestamp:
+                source: time
+                format: RFC3339
+      - labeldrop:
+          - filename
+          - stream
+

--- a/docker-compose.loki.yml
+++ b/docker-compose.loki.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  bot:
+    labels:
+      - "app=paperbot"
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    command: ["-config.file=/etc/loki/config.yml"]
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./config/loki/config.yml:/etc/loki/config.yml:ro
+      - loki-data:/loki
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    depends_on:
+      - loki
+    command: ["-config.file=/etc/promtail/config.yml"]
+    volumes:
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./config/promtail/config.yml:/etc/promtail/config.yml:ro
+
+volumes:
+  loki-data:
+    driver: local
+

--- a/docker-compose.loki.yml
+++ b/docker-compose.loki.yml
@@ -6,7 +6,7 @@ services:
       - "app=paperbot"
 
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:2.9.0
     container_name: loki
     command: ["-config.file=/etc/loki/config.yml"]
     ports:
@@ -29,4 +29,3 @@ services:
 volumes:
   loki-data:
     driver: local
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - ./src:/app/src
       - ./config:/app/config
     restart: unless-stopped
+    environment:
+      - REDIS_URL=redis://redis:6379/0
 
   prometheus:
     image: prom/prometheus:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,14 @@ services:
       - ./config/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - prometheus
+  redis:
+    image: redis:7
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: ["redis-server", "--appendonly", "yes"]
+
+volumes:
+  redis-data:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -61,8 +61,9 @@ Turn strategy signals into paper orders and simulated fills, track PnL and equit
   - Intents rate by pattern/side (5m)
   - Latency P50/P95 (s)
 - Loki logs (when running with `-f docker-compose.loki.yml`):
-  - `{app="paperbot"} | json | event="pattern_detected"`
-  - `{app="paperbot"} | json | event="pattern_intent"`
+  - `{app="paperbot"} |= "pattern_detected"`
+  - `{app="paperbot"} |= "pattern_intent"`
+  - Optional JSON filter (if supported): `{app="paperbot"} | json | event == "pattern_detected"`
 
 
 ## Metrics to Validate

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -41,12 +41,29 @@ Turn strategy signals into paper orders and simulated fills, track PnL and equit
 - Metrics validation:
   - Prometheus: http://localhost:9090/targets (job `paperbot` UP), http://localhost:9090/graph
   - Grafana (anonymous): http://localhost:3000 → Paperbot Overview
-  - PromQL examples:
+- PromQL examples:
     - `sum by (type,symbol) (orders_submitted_total)`
     - `sum by (liquidity,symbol) (fills_total)`
     - `sum by (symbol) (fees_paid_total)`
     - `equity_gauge`
     - `killswitch_trips_total`
+
+## Pattern Observability (Phase 2.5)
+- Env flags:
+  - `ENABLE_PATTERN_OBS_DEMO=1` to enable a tiny synthetic emitter
+  - `PATTERN_OBS_DEMO_SECONDS=15` interval (seconds)
+- Run demo (Compose with Loki optional):
+  - `ENABLE_PATTERN_OBS_DEMO=1 PATTERN_OBS_DEMO_SECONDS=10 docker compose up`
+- Verify Prometheus metrics:
+  - `curl -s http://localhost:8000/metrics | egrep 'pattern_detected_total|pattern_intent_total|pattern_to_intent_latency_seconds_bucket'`
+- Grafana panels (Paperbot Overview → row "Patterns"):
+  - Detections rate by pattern (5m)
+  - Intents rate by pattern/side (5m)
+  - Latency P50/P95 (s)
+- Loki logs (when running with `-f docker-compose.loki.yml`):
+  - `{app="paperbot"} | json | event="pattern_detected"`
+  - `{app="paperbot"} | json | event="pattern_intent"`
+
 
 ## Metrics to Validate
 - Data/Features (prior phases): `candles_fetched_total`, `features_computed_total`

--- a/docs/decisions/ADR-0012-pattern-observability.md
+++ b/docs/decisions/ADR-0012-pattern-observability.md
@@ -34,8 +34,9 @@ Sample Queries
   - `histogram_quantile(0.5, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
   - `histogram_quantile(0.95, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
 - Loki (logs):
-  - `{app="paperbot"} | json | event="pattern_detected"`
-  - `{app="paperbot"} | json | event="pattern_intent"`
+  - `{app="paperbot"} |= "pattern_detected"`
+  - `{app="paperbot"} |= "pattern_intent"`
+  - Optional JSON filter (if supported): `| json | event == "pattern_detected"`
 
 Consequences
 - Minimal, backwards-compatible additions; no impact to trading logic.

--- a/docs/decisions/ADR-0012-pattern-observability.md
+++ b/docs/decisions/ADR-0012-pattern-observability.md
@@ -1,0 +1,42 @@
+# ADR-0012: Pattern Observability (Phase 2.5)
+
+Context
+- Add lightweight, strategy-agnostic observability for candlestick pattern events.
+- Avoid dependency on unmerged strategy code; provide an ENV-gated synthetic emitter.
+
+Decisions
+- Counters and histogram in `src/paperbot/metrics/exec.py`:
+  - Counter: `pattern_detected_total{market,symbol,pattern}`
+  - Counter: `pattern_intent_total{market,pattern,side}`
+  - Histogram: `pattern_to_intent_latency_seconds` with buckets `[0.5,1,2,5,10,30,60]`
+- Structured logs (Loki) via helper in `src/paperbot/logs/decision_log.py`:
+  - `log_pattern_event(event, market, symbol, pattern, rsi=None, side=None, ts=None, extra=None)`
+  - JSON keys: `event` ("pattern_detected"|"pattern_intent"), `market`, `symbol`, `pattern`, `rsi`, `side`, `ts`, `severity`, `component="strategy"`, `schema_version="v1"`.
+- Thin wiring helpers in `src/paperbot/strategies/runner.py`:
+  - `record_pattern_detected(market, symbol, pattern, rsi, ts)`
+  - `record_pattern_intent(market, symbol, pattern, side, ts_detected, ts_intent)`
+- Synthetic demo emitter (env-gated) in `src/paperbot/main.py`:
+  - Enabled when `ENABLE_PATTERN_OBS_DEMO=1`.
+  - Emits BTC/USDT bullish_engulfing every `PATTERN_OBS_DEMO_SECONDS` (default 15s)
+  - Emits intent ~0.5s later; records latency.
+- Grafana: a new row “Patterns” with timeseries/stat/quantile panels and Loki log panels.
+- Alert: `config/grafana/provisioning/alerting/patterns-min-activity.yml` alerts if zero detections for 30m (for 45m).
+
+Env Flags
+- `ENABLE_PATTERN_OBS_DEMO` (default `0`) — enable synthetic emitter
+- `PATTERN_OBS_DEMO_SECONDS` (default `15`) — emit interval in seconds
+
+Sample Queries
+- Prometheus (rate):
+  - `sum by (pattern) (rate(pattern_detected_total[5m]))`
+  - `sum by (pattern,side) (rate(pattern_intent_total[5m]))`
+- Prometheus (latency):
+  - `histogram_quantile(0.5, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
+  - `histogram_quantile(0.95, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
+- Loki (logs):
+  - `{app="paperbot"} | json | event="pattern_detected"`
+  - `{app="paperbot"} | json | event="pattern_intent"`
+
+Consequences
+- Minimal, backwards-compatible additions; no impact to trading logic.
+- Ready-made wiring points for real strategies without new dependencies.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -10,6 +10,7 @@ This folder contains Architecture Decision Records (ADRs) documenting key decisi
 - ADR-0005-branching-and-releases.md — phase branches, PRs, tags
 - ADR-0006-execution-profiles.md — exchange-specific fees/rounding/minimums/slippage
 - ADR-0007-partial-fills.md — liquidity_fraction and remaining qty semantics
+- ADR-0012-pattern-observability.md — counters/histograms and Loki logs for candlestick patterns (Phase 2.5)
 
 ## How to add an ADR
 1. Copy `ADR-0000-template.md` to the next number (e.g., `ADR-0006-<topic>.md`).

--- a/docs/pr/phase-2-5-events-notifications.md
+++ b/docs/pr/phase-2-5-events-notifications.md
@@ -1,0 +1,60 @@
+# Phase 2.5: Pattern Observability (Events + Notifications)
+
+## Summary
+Introduce lightweight, strategy-agnostic observability for candlestick pattern events. Adds Prometheus counters/histogram, Loki-structured logs, Grafana panels, a simple alert, and an ENV-gated synthetic emitter to validate locally without depending on unmerged strategy code.
+
+## Changes
+- Metrics (src/paperbot/metrics/exec.py)
+  - Counter: `pattern_detected_total{market,symbol,pattern}`
+  - Counter: `pattern_intent_total{market,pattern,side}`
+  - Histogram: `pattern_to_intent_latency_seconds` with buckets `[0.5,1,2,5,10,30,60]`
+  - Helpers: `inc_pattern_detected`, `inc_pattern_intent`, `observe_pattern_to_intent_latency`
+- Structured logs (src/paperbot/logs/decision_log.py)
+  - `log_pattern_event(event_type, market, symbol, pattern, rsi=None, side=None, ts=None, extra=None)`
+  - Emits JSON for Loki with keys: `event`, `market`, `symbol`, `pattern`, `rsi`, `side`, `ts`, `severity`, `component`, `schema_version`.
+- Strategy wiring points (src/paperbot/strategies/runner.py)
+  - `record_pattern_detected(...)` and `record_pattern_intent(...)` (no dependency on specific strategies)
+- Demo emitter (src/paperbot/main.py)
+  - ENV-gated: `ENABLE_PATTERN_OBS_DEMO=1`; interval `PATTERN_OBS_DEMO_SECONDS` (default 15)
+  - Emits BTC/USDT `pattern_detected` (bullish_engulfing, rsi=33) then `pattern_intent` (long) after ~0.5s
+- Grafana (config/grafana/provisioning/dashboards/paperbot.json)
+  - New row “Patterns”: detections rate, intents rate, latency P50/P95, Loki logs panels
+- Alert (config/grafana/provisioning/alerting/patterns-min-activity.yml)
+  - If `sum(increase(pattern_detected_total[30m])) == 0` for 45m → “No pattern detections (30m)”
+  - Datasource UID: `PBFA97CFB590B2093`
+- Docs
+  - ADR: `docs/decisions/ADR-0012-pattern-observability.md`
+  - Runbook: new section “Pattern Observability (Phase 2.5)”
+  - README: features bullet linking to ADR + Runbook
+  - .env example: `src/paperbot/.env.example`
+- Tooling
+  - Smoke script: `scripts/smoke_pattern_obs.sh`
+- Tests
+  - `tests/test_pattern_observability.py` covering counters/logs/histogram
+
+## How to Run
+- Compose (Prometheus+Grafana):
+  - `ENABLE_PATTERN_OBS_DEMO=1 PATTERN_OBS_DEMO_SECONDS=10 docker compose up`
+- Validate metrics:
+  - `curl -s http://localhost:8000/metrics | egrep 'pattern_detected_total|pattern_intent_total|pattern_to_intent_latency_seconds_bucket'`
+- Grafana → Paperbot Overview → Patterns row
+  - P50: `histogram_quantile(0.5, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
+  - P95: `histogram_quantile(0.95, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
+- Loki (optional overlay `-f docker-compose.loki.yml`):
+  - `{app="paperbot"} | json | event="pattern_detected"`
+  - `{app="paperbot"} | json | event="pattern_intent"`
+
+## Compatibility
+- Additive; no changes to existing strategy/execution flows.
+- Metrics use safe getters; tolerant in constrained envs and tests.
+
+## Checklist
+- [x] Metrics compile and export
+- [x] Logs JSON parse in Grafana Loki
+- [x] Panels present under “Patterns”
+- [x] Alert provisioned
+- [x] Smoke and unit tests present
+
+## Links
+- ADR: `docs/decisions/ADR-0012-pattern-observability.md`
+- Runbook: `docs/RUNBOOK.md#pattern-observability-phase-25`

--- a/docs/pr/phase-2-5-events-notifications.md
+++ b/docs/pr/phase-2-5-events-notifications.md
@@ -41,8 +41,10 @@ Introduce lightweight, strategy-agnostic observability for candlestick pattern e
   - P50: `histogram_quantile(0.5, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
   - P95: `histogram_quantile(0.95, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
 - Loki (optional overlay `-f docker-compose.loki.yml`):
-  - `{app="paperbot"} | json | event="pattern_detected"`
-  - `{app="paperbot"} | json | event="pattern_intent"`
+  - `{app="paperbot"} |= "pattern_detected"`
+  - `{app="paperbot"} |= "pattern_intent"`
+  - Note: If you prefer JSON filtering and your Loki supports it, use
+    `{app="paperbot"} | json | event == "pattern_detected"` (and `pattern_intent`).
 
 ## Compatibility
 - Additive; no changes to existing strategy/execution flows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ matplotlib = "*"
 duckdb = "*"
 python-dotenv = "*"
 pyyaml = "*"
+redis = "*"
+fastapi = "*"
+uvicorn = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ pandas = "*"
 numpy = "*"
 pyarrow = "*"
 ta = "*"
-pandas-ta = "<0.4"  # 0.4.x requires Python >=3.12; pin for Py3.11 image
 pydantic = "*"
 prometheus_client = "*"
 jinja2 = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pandas = "*"
 numpy = "*"
 pyarrow = "*"
 ta = "*"
-pandas-ta = "*"
+pandas-ta = "<0.4"  # 0.4.x requires Python >=3.12; pin for Py3.11 image
 pydantic = "*"
 prometheus_client = "*"
 jinja2 = "*"

--- a/scripts/smoke_pattern_obs.sh
+++ b/scripts/smoke_pattern_obs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=${PROMETHEUS_PORT:-8000}
+URL="http://localhost:${PORT}/metrics"
+
+echo "[smoke] Checking Paperbot metrics at ${URL}"
+
+# Try to curl a few times in case the app is starting up
+tries=0
+until curl -fsS "$URL" >/tmp/metrics.$$ 2>/dev/null || [[ $tries -ge 10 ]]; do
+  tries=$((tries+1))
+  sleep 1
+done
+
+if [[ ! -s /tmp/metrics.$$ ]]; then
+  echo "[smoke] Could not fetch metrics. Is the app running?"
+  echo "Hint: ENABLE_PATTERN_OBS_DEMO=1 docker compose up --build"
+  exit 1
+fi
+
+ok=0
+grep -q '^pattern_detected_total' /tmp/metrics.$$ && ok=$((ok+1))
+grep -q '^pattern_intent_total' /tmp/metrics.$$ && ok=$((ok+1))
+grep -q '^pattern_to_intent_latency_seconds_bucket' /tmp/metrics.$$ && ok=$((ok+1))
+
+rm -f /tmp/metrics.$$
+
+if [[ $ok -lt 3 ]]; then
+  echo "[smoke] Missing expected pattern metrics. Ensure ENABLE_PATTERN_OBS_DEMO=1 and wait one interval."
+  echo "Check: curl -s ${URL} | egrep 'pattern_detected_total|pattern_intent_total|pattern_to_intent_latency_seconds_bucket'"
+  exit 2
+fi
+
+echo "[smoke] OK: pattern metrics present."

--- a/services/sse_gateway/main.py
+++ b/services/sse_gateway/main.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import json
+import asyncio
+from typing import AsyncGenerator, Optional, List
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+STREAM = os.getenv("EVENTS_STREAM", "paperbot.events")
+GROUP = os.getenv("SSE_GROUP", "sse_gateway")
+
+try:
+    import redis.asyncio as aioredis
+except Exception:  # pragma: no cover
+    aioredis = None  # type: ignore
+
+app = FastAPI(title="Paperbot SSE Gateway")
+
+
+async def ensure_group(r):
+    try:
+        await r.xgroup_create(name=STREAM, groupname=GROUP, id="$", mkstream=True)
+    except Exception as e:  # BUSYGROUP
+        if "BUSYGROUP" in str(e):
+            return
+
+
+def _match_filters(js: str, types: Optional[List[str]], symbols: Optional[List[str]]) -> bool:
+    try:
+        data = json.loads(js)
+        ev = data.get("event", {})
+        t = ev.get("event_type")
+        s = ev.get("symbol")
+        ok_t = True if not types else t in types
+        ok_s = True if not symbols else s in symbols
+        return ok_t and ok_s
+    except Exception:
+        return False
+
+
+async def event_stream(types: Optional[List[str]], symbols: Optional[List[str]]) -> AsyncGenerator[bytes, None]:
+    if aioredis is None:  # pragma: no cover
+        yield b": redis async client missing\n\n"
+        return
+    r = aioredis.from_url(REDIS_URL, decode_responses=True)
+    await ensure_group(r)
+    consumer = os.getenv("SSE_CONSUMER", os.uname().nodename)
+    heartbeat = 0
+    try:
+        while True:
+            resp = await r.xreadgroup(GROUP, consumer, {STREAM: ">"}, count=100, block=15000)
+            if resp:
+                for _stream, entries in resp:
+                    for msg_id, fields in entries:
+                        js = fields.get("json", "")
+                        if _match_filters(js, types, symbols):
+                            yield f"event: event\ndata: {js}\n\n".encode()
+                        await r.xack(STREAM, GROUP, msg_id)
+            else:
+                heartbeat += 1
+                if heartbeat % 1 == 0:
+                    yield b": keep-alive\n\n"
+    finally:
+        await r.aclose()
+
+
+@app.get("/events")
+async def sse(request: Request, types: Optional[str] = None, symbols: Optional[str] = None):
+    ty = types.split(",") if types else None
+    sy = symbols.split(",") if symbols else None
+    generator = event_stream(ty, sy)
+    return StreamingResponse(generator, media_type="text/event-stream")
+

--- a/src/paperbot/events/bus.py
+++ b/src/paperbot/events/bus.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import os
+import logging
+from typing import Any, Dict
+
+try:
+    import redis
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
+from .schema import EventEnvelope
+from .metrics import get_events_total, get_orders_rejected_total
+
+
+STREAM_EVENTS = os.getenv("EVENTS_STREAM", "paperbot.events")
+STREAM_DLQ = os.getenv("EVENTS_DLQ", "paperbot.dlq")
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+log = logging.getLogger("paperbot.events")
+
+
+def _get_redis():
+    if redis is None:
+        raise RuntimeError("redis client not available")
+    return redis.Redis.from_url(REDIS_URL, decode_responses=True)
+
+
+def publish(env: EventEnvelope) -> None:
+    """Publish an event to Redis Streams and log a single-line JSON for Loki.
+
+    Safe: swallow errors if Redis is not reachable to avoid impacting trading loop.
+    """
+    # Metrics: total per type
+    try:
+        get_events_total().labels(env.event.event_type).inc()
+        if env.event.event_type == "order_rejected":
+            reason = getattr(env.event, "reason", "unknown")
+            get_orders_rejected_total().labels(reason).inc()
+    except Exception:
+        pass
+
+    line = json.dumps({
+        "schema_version": env.schema_version,
+        "correlation_id": env.correlation_id,
+        "sequence": env.sequence,
+        "event": env.event.model_dump(),
+    }, separators=(",", ":"))
+    try:
+        r = _get_redis()
+        r.xadd(STREAM_EVENTS, {"json": line})
+    except Exception:
+        try:
+            # best-effort DLQ
+            r = _get_redis()
+            r.xadd(STREAM_DLQ, {"json": line})
+        except Exception:
+            pass
+    # Always log for Loki ingestion
+    try:
+        log.info(line)
+    except Exception:
+        pass
+
+
+def ensure_group(group: str) -> None:
+    try:
+        r = _get_redis()
+        # Create the group if it doesn't exist
+        r.xgroup_create(name=STREAM_EVENTS, groupname=group, id="$", mkstream=True)
+    except Exception as e:
+        if "BUSYGROUP" in str(e):
+            return
+
+
+def consume(group: str, consumer: str, block_ms: int = 15000):
+    """Generator yielding (id, json_str) from Redis Stream consumer group.
+
+    Caller is responsible for acknowledging XACK.
+    """
+    r = _get_redis()
+    ensure_group(group)
+    while True:
+        resp = r.xreadgroup(group, consumer, {STREAM_EVENTS: ">"}, count=100, block=block_ms)
+        if not resp:
+            yield None
+            continue
+        # resp is list[(stream, [(id, {field:value}), ...])]
+        for _stream, entries in resp:
+            for msg_id, fields in entries:
+                yield (msg_id, fields.get("json", ""))
+

--- a/src/paperbot/events/metrics.py
+++ b/src/paperbot/events/metrics.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Optional
+from prometheus_client import Counter, Histogram, REGISTRY
+
+_events_total: Optional[Counter] = None
+_orders_rejected_total: Optional[Counter] = None
+_order_fill_latency_seconds: Optional[Histogram] = None
+_slippage_bps: Optional[Histogram] = None
+
+
+def get_events_total():
+    global _events_total
+    if _events_total is None:
+        _events_total = Counter("events_total", "Paperbot events", ["type"])  # type: ignore[arg-type]
+    return _events_total
+
+
+def get_orders_rejected_total():
+    global _orders_rejected_total
+    if _orders_rejected_total is None:
+        _orders_rejected_total = Counter("orders_rejected_total", "Orders rejected", ["reason"])  # type: ignore[arg-type]
+    return _orders_rejected_total
+
+
+def get_order_fill_latency_seconds():
+    global _order_fill_latency_seconds
+    if _order_fill_latency_seconds is None:
+        _order_fill_latency_seconds = Histogram(
+            "order_fill_latency_seconds",
+            "Latency from submit to fill",
+            buckets=(0.5, 1, 2, 5, 10, 30, 60),
+        )
+    return _order_fill_latency_seconds
+
+
+def get_slippage_bps():
+    global _slippage_bps
+    if _slippage_bps is None:
+        _slippage_bps = Histogram(
+            "slippage_bps",
+            "Slippage in basis points",
+            buckets=(0.1, 0.5, 1, 2, 5, 10, 20),
+        )
+    return _slippage_bps
+

--- a/src/paperbot/events/schema.py
+++ b/src/paperbot/events/schema.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import List, Literal, Optional, Union
+from pydantic import BaseModel, Field
+
+
+# ---- Base + envelope ----
+
+class BaseEvent(BaseModel):
+    event_type: str
+    ts: int
+    run_id: str = "r1"
+    market: str
+    symbol: str
+    strategy: Optional[str] = None
+    side: Optional[str] = None  # long|short|flat or buy|sell
+    confidence: Optional[float] = None
+    tags: List[str] = []
+
+
+class EventEnvelope(BaseModel):
+    schema_version: str = "v1"
+    correlation_id: str
+    sequence: int = 0
+    event: BaseEvent
+
+
+# ---- Event types ----
+
+class SignalDetected(BaseEvent):
+    event_type: Literal["signal_detected"] = "signal_detected"
+    pattern_id: Optional[str] = None
+    threshold: Optional[float] = None
+
+
+class PatternBreak(BaseEvent):
+    event_type: Literal["pattern_break"] = "pattern_break"
+    breakout_level: Optional[float] = None
+    strength: Optional[float] = None
+
+
+class OrderIntent(BaseEvent):
+    event_type: Literal["order_intent"] = "order_intent"
+    notional_usd: float = 0.0
+
+
+class OrderSubmitted(BaseEvent):
+    event_type: Literal["order_submitted"] = "order_submitted"
+    order_id: str
+    qty: float
+    price: Optional[float] = None
+
+
+class OrderPartiallyFilled(BaseEvent):
+    event_type: Literal["order_partially_filled"] = "order_partially_filled"
+    order_id: str
+    qty: float
+    price: float
+    fee_usd: float = 0.0
+    slippage_bps: Optional[float] = None
+
+
+class OrderFilled(BaseEvent):
+    event_type: Literal["order_filled"] = "order_filled"
+    order_id: str
+    qty: float
+    avg_price: float
+    fee_usd: float = 0.0
+
+
+class OrderCanceled(BaseEvent):
+    event_type: Literal["order_canceled"] = "order_canceled"
+    order_id: str
+    reason: str
+
+
+class OrderRejected(BaseEvent):
+    event_type: Literal["order_rejected"] = "order_rejected"
+    reason: str
+
+
+class RiskBlocked(BaseEvent):
+    event_type: Literal["risk_blocked"] = "risk_blocked"
+    reason: str
+
+
+class DayHighlight(BaseEvent):
+    event_type: Literal["day_highlight"] = "day_highlight"
+    summary: str
+
+
+class Heartbeat(BaseEvent):
+    event_type: Literal["heartbeat"] = "heartbeat"
+    service: str = "bot"
+
+
+AnyEvent = Union[
+    SignalDetected,
+    PatternBreak,
+    OrderIntent,
+    OrderSubmitted,
+    OrderPartiallyFilled,
+    OrderFilled,
+    OrderCanceled,
+    OrderRejected,
+    RiskBlocked,
+    DayHighlight,
+    Heartbeat,
+]
+

--- a/src/paperbot/logs/decision_log.py
+++ b/src/paperbot/logs/decision_log.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+import logging
+import time
 
 try:
     from ..metrics.exec import _safe_counter  # type: ignore
@@ -49,3 +51,39 @@ def append_jsonl(path: str, rec: Dict[str, Any]) -> None:
         app.labels(market).inc()
     except Exception:
         err.labels("io_error", market).inc()
+
+
+def log_pattern_event(
+    event_type: str,
+    market: str,
+    symbol: str,
+    pattern: str,
+    rsi: Optional[float] = None,
+    side: Optional[str] = None,
+    ts: Optional[int] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a structured JSON log line for pattern observability.
+
+    Keys: event, market, symbol, pattern, rsi, side, ts, severity, component, schema_version
+    """
+    try:
+        logger = logging.getLogger("paperbot.strategy")
+        payload: Dict[str, Any] = {
+            "event": str(event_type),
+            "market": str(market),
+            "symbol": str(symbol),
+            "pattern": str(pattern),
+            "rsi": float(rsi) if rsi is not None else None,
+            "side": str(side) if side is not None else None,
+            "ts": int(ts if ts is not None else int(time.time() * 1000)),
+            "severity": "INFO",
+            "component": "strategy",
+            "schema_version": "v1",
+        }
+        if extra:
+            payload["extra"] = extra
+        logger.info(json.dumps(payload, separators=(",", ":")))
+    except Exception:
+        # Logging must never throw
+        pass

--- a/src/paperbot/main.py
+++ b/src/paperbot/main.py
@@ -21,6 +21,7 @@ import logging
 import os
 import yaml
 import time
+import threading
 from paperbot.config.loader import load_settings
 from paperbot.features.feature_builder import FeatureBuilder
 from prometheus_client import start_http_server, Counter
@@ -237,6 +238,38 @@ def main() -> None:
             pass
         # Write outputs
         ledger.write_parquet("data")
+
+        # Optional: start a lightweight MTM ticker (does not affect core demo determinism)
+        try:
+            from paperbot.metrics.exec import set_equity_gauges, get_mtm_tick_total
+            tick_secs = int(os.getenv("MTM_TICK_SECONDS", os.getenv("EQUITY_TICK_SECONDS", "15")))
+            enable_tick = os.getenv("ENABLE_MTM_TICK", "0") == "1"
+            hold = int(os.getenv("HOLD_METRICS_SECONDS", "0"))
+            if enable_tick and tick_secs > 0 and hold > 0:
+                mtm_counter = get_mtm_tick_total()
+
+                # Capture last known prices for a simple MTM tick; in demo we reuse last close
+                last_prices = {s: 100.0 for s in settings.symbols}
+
+                def _mtm_loop(duration_s: int):
+                    deadline = time.time() + duration_s
+                    while time.time() < deadline:
+                        # Recompute equity snapshot and emit gauges
+                        try:
+                            # Reuse last price (demo); in online mode, fetcher would supply fresh prices
+                            ledger.mark_to_market(int(time.time() * 1000), last_prices)
+                            set_equity_gauges({
+                                "crypto": float(ledger.equity),
+                            })
+                            mtm_counter.labels("crypto").inc()
+                        except Exception:
+                            pass
+                        time.sleep(tick_secs)
+
+                t = threading.Thread(target=_mtm_loop, args=(hold,), daemon=True)
+                t.start()
+        except Exception:
+            pass
         # LLM Advisory demo (advisory only; no live orders)
         try:
             from paperbot.llm.router import load_llm_config, get_client
@@ -402,6 +435,29 @@ def main() -> None:
                 signals_remaining -= 1
     
     logging.info("candle demo complete")
+    # Optional: start a lightweight MTM ticker for online/demo mode
+    try:
+        from paperbot.metrics.exec import set_equity_gauges, get_mtm_tick_total
+        tick_secs = int(os.getenv("MTM_TICK_SECONDS", os.getenv("EQUITY_TICK_SECONDS", "15")))
+        enable_tick = os.getenv("ENABLE_MTM_TICK", "1") == "1"
+        # Online mode may not have a ledger; synthesize a basic equity tracker from start equity
+        equity_usd = float(os.getenv("EQUITY_START_USD", "10000"))
+        mtm_counter = get_mtm_tick_total()
+
+        if enable_tick and tick_secs > 0:
+            def _mtm_loop_online():
+                while True:
+                    try:
+                        # Emit a steady equity value as a heartbeat; strategies can update later when ledger is introduced
+                        set_equity_gauges({"crypto": equity_usd})
+                        mtm_counter.labels("crypto").inc()
+                    except Exception:
+                        pass
+                    time.sleep(tick_secs)
+
+            threading.Thread(target=_mtm_loop_online, daemon=True).start()
+    except Exception:
+        pass
     logging.info("strategy demo complete")
     # ---- Phase 3.0: LLM Advisory (offline advisory; simulated only) ----
     try:

--- a/src/paperbot/metrics/exec.py
+++ b/src/paperbot/metrics/exec.py
@@ -34,10 +34,13 @@ def _safe_counter(name: str, doc: str, labelnames):
     try:
         return Counter(name, doc, labelnames)
     except ValueError:
-        # Try to find existing collector in default REGISTRY
+        # Try to find existing collector in default REGISTRY (by name)
         try:
-            for coll in list(REGISTRY._collector_to_names.keys()):  # type: ignore[attr-defined]
-                if isinstance(coll, Counter) and getattr(coll, "_name", None) == name:
+            coll = getattr(REGISTRY, "_names_to_collectors", {}).get(name)
+            if coll is not None:
+                return coll
+            for coll in list(getattr(REGISTRY, "_collector_to_names", {}).keys()):  # type: ignore[attr-defined]
+                if getattr(coll, "_name", None) == name:
                     return coll
         except Exception:
             pass
@@ -88,8 +91,11 @@ def _safe_histogram(name: str, doc: str, labelnames=None, buckets=None):
             return Histogram(name, doc)
     except ValueError:
         try:
-            for coll in list(REGISTRY._collector_to_names.keys()):  # type: ignore[attr-defined]
-                if isinstance(coll, Histogram) and getattr(coll, "_name", None) == name:
+            coll = getattr(REGISTRY, "_names_to_collectors", {}).get(name)
+            if coll is not None:
+                return coll
+            for coll in list(getattr(REGISTRY, "_collector_to_names", {}).keys()):  # type: ignore[attr-defined]
+                if getattr(coll, "_name", None) == name:
                     return coll
         except Exception:
             pass

--- a/src/paperbot/metrics/exec.py
+++ b/src/paperbot/metrics/exec.py
@@ -13,6 +13,7 @@ _equity_gauge: Optional[Gauge] = None
 _killswitch_trips: Optional[Counter] = None
 _fees_paid_usd_total: Optional[Counter] = None
 _account_equity_usd: Optional[Gauge] = None
+_mtm_tick_total: Optional[Counter] = None
 
 
 class _NoOp:
@@ -137,6 +138,16 @@ def get_account_equity_usd():
             "account_equity_usd", "Account equity in USD", ["market"]
         )
     return _account_equity_usd
+
+
+def get_mtm_tick_total():
+    """Counter: count of MTM ticks executed per market."""
+    global _mtm_tick_total
+    if _mtm_tick_total is None:
+        _mtm_tick_total = _safe_counter(
+            "mtm_tick_total", "Mark-to-market ticks executed", ["market"]
+        )
+    return _mtm_tick_total
 
 
 def set_equity_gauges(equity_by_market: Dict[str, float]) -> None:

--- a/src/paperbot/metrics/exec.py
+++ b/src/paperbot/metrics/exec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, Dict
 import os
-from prometheus_client import Counter, Gauge, REGISTRY
+from prometheus_client import Counter, Gauge, Histogram, REGISTRY
 
 _orders_submitted: Optional[Counter] = None
 _orders_blocked: Optional[Counter] = None
@@ -14,6 +14,9 @@ _killswitch_trips: Optional[Counter] = None
 _fees_paid_usd_total: Optional[Counter] = None
 _account_equity_usd: Optional[Gauge] = None
 _mtm_tick_total: Optional[Counter] = None
+_pattern_detected_total: Optional[Counter] = None
+_pattern_intent_total: Optional[Counter] = None
+_pattern_to_intent_latency: Optional[Histogram] = None
 
 
 class _NoOp:
@@ -65,6 +68,28 @@ def _safe_gauge_labels(name: str, doc: str, labelnames):
         try:
             for coll in list(REGISTRY._collector_to_names.keys()):  # type: ignore[attr-defined]
                 if isinstance(coll, Gauge) and getattr(coll, "_name", None) == name:
+                    return coll
+        except Exception:
+            pass
+        return _NoOp()
+
+
+def _safe_histogram(name: str, doc: str, labelnames=None, buckets=None):
+    if os.getenv("DISABLE_PROMETHEUS", "0") == "1":
+        return _NoOp()
+    try:
+        if labelnames is not None and buckets is not None:
+            return Histogram(name, doc, labelnames, buckets=buckets)
+        elif labelnames is not None:
+            return Histogram(name, doc, labelnames)
+        elif buckets is not None:
+            return Histogram(name, doc, buckets=buckets)
+        else:
+            return Histogram(name, doc)
+    except ValueError:
+        try:
+            for coll in list(REGISTRY._collector_to_names.keys()):  # type: ignore[attr-defined]
+                if isinstance(coll, Histogram) and getattr(coll, "_name", None) == name:
                     return coll
         except Exception:
             pass
@@ -169,3 +194,66 @@ def get_killswitch_trips_total():
     if _killswitch_trips is None:
         _killswitch_trips = _safe_counter("killswitch_trips_total", "Kill switch trips", [])
     return _killswitch_trips
+
+
+# ---- Phase 2.5: Pattern observability ----
+
+def get_pattern_detected_total():
+    """Counter: pattern_detected_total{market,symbol,pattern}"""
+    global _pattern_detected_total
+    if _pattern_detected_total is None:
+        _pattern_detected_total = _safe_counter(
+            "pattern_detected_total", "Candlestick patterns detected", ["market", "symbol", "pattern"]
+        )
+    return _pattern_detected_total
+
+
+def get_pattern_intent_total():
+    """Counter: pattern_intent_total{market,pattern,side}"""
+    global _pattern_intent_total
+    if _pattern_intent_total is None:
+        _pattern_intent_total = _safe_counter(
+            "pattern_intent_total", "Intents emitted for patterns", ["market", "pattern", "side"]
+        )
+    return _pattern_intent_total
+
+
+def get_pattern_to_intent_latency():
+    """Histogram: pattern_to_intent_latency_seconds
+
+    Buckets: [0.5, 1, 2, 5, 10, 30, 60]
+    """
+    global _pattern_to_intent_latency
+    if _pattern_to_intent_latency is None:
+        _pattern_to_intent_latency = _safe_histogram(
+            "pattern_to_intent_latency_seconds",
+            "Latency seconds from pattern detection to intent emission",
+            buckets=(0.5, 1, 2, 5, 10, 30, 60),
+        )
+    return _pattern_to_intent_latency
+
+
+def inc_pattern_detected(market: str, symbol: str, pattern: str) -> None:
+    try:
+        get_pattern_detected_total().labels(market, symbol, pattern).inc()
+    except Exception:
+        pass
+
+
+def inc_pattern_intent(market: str, pattern: str, side: str) -> None:
+    try:
+        get_pattern_intent_total().labels(market, pattern, side).inc()
+    except Exception:
+        pass
+
+
+def observe_pattern_to_intent_latency(seconds: float) -> None:
+    if seconds is None:
+        return
+    try:
+        if seconds < 0:
+            # guard: only positive observations
+            return
+        get_pattern_to_intent_latency().observe(float(seconds))
+    except Exception:
+        pass

--- a/tests/test_events_bus.py
+++ b/tests/test_events_bus.py
@@ -1,0 +1,28 @@
+import os
+import socket
+import time
+
+import pytest
+
+from src.paperbot.events.schema import EventEnvelope, OrderIntent
+from src.paperbot.events import bus
+
+
+def _redis_up(host='localhost', port=6379):
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _redis_up(), reason="redis not running on localhost:6379")
+def test_bus_publish_consume_roundtrip():
+    os.environ['REDIS_URL'] = 'redis://localhost:6379/0'
+    env = EventEnvelope(correlation_id='cX', event=OrderIntent(ts=1, market='crypto', symbol='BTC/USDT', strategy='s', side='long', confidence=0.9, notional_usd=100.0))
+    bus.publish(env)
+    bus.ensure_group('g1')
+    it = bus.consume('g1', 'c1', block_ms=1000)
+    msg = next(it)
+    assert msg is None or isinstance(msg, tuple)
+

--- a/tests/test_events_schema.py
+++ b/tests/test_events_schema.py
@@ -1,0 +1,18 @@
+from src.paperbot.events.schema import (
+    EventEnvelope, OrderIntent, OrderSubmitted, OrderPartiallyFilled, OrderFilled,
+)
+
+
+def test_event_envelope_roundtrip():
+    intent = OrderIntent(ts=1, market="crypto", symbol="BTC/USDT", strategy="s", side="long", confidence=0.9, notional_usd=100.0)
+    env = EventEnvelope(correlation_id="c1", event=intent)
+    js = env.model_dump_json()
+    assert 'order_intent' in js
+
+
+def test_order_events_models():
+    sub = OrderSubmitted(ts=2, market="crypto", symbol="BTC/USDT", strategy="s", side="buy", order_id="o1", qty=1.0)
+    pf = OrderPartiallyFilled(ts=3, market="crypto", symbol="BTC/USDT", strategy="s", side="buy", order_id="o1", qty=0.5, price=100.0, fee_usd=0.01)
+    full = OrderFilled(ts=4, market="crypto", symbol="BTC/USDT", strategy="s", side="buy", order_id="o1", qty=1.0, avg_price=100.05, fee_usd=0.02)
+    assert sub.order_id == pf.order_id == full.order_id == "o1"
+

--- a/tests/test_pattern_observability.py
+++ b/tests/test_pattern_observability.py
@@ -1,0 +1,41 @@
+import logging
+from prometheus_client import REGISTRY
+
+from src.paperbot.strategies.runner import record_pattern_detected, record_pattern_intent
+
+
+def test_record_pattern_helpers_emit_metrics_and_logs(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+
+    market = "crypto"
+    symbol = "BTC/USDT"
+    pattern = "bullish_engulfing"
+    side = "long"
+    ts_det = 1_000  # ms
+    ts_int = 1_600  # ms -> 0.6s latency
+
+    record_pattern_detected(market, symbol, pattern, rsi=33.0, ts=ts_det)
+    record_pattern_intent(market, symbol, pattern, side=side, ts_detected=ts_det, ts_intent=ts_int)
+
+    # Logs contain JSON with event types
+    log_out = "\n".join([r.message for r in caplog.records])
+    assert '"event":"pattern_detected"' in log_out
+    assert '"event":"pattern_intent"' in log_out
+
+    # Counters incremented
+    v_det = REGISTRY.get_sample_value(
+        "pattern_detected_total", {"market": market, "symbol": symbol, "pattern": pattern}
+    )
+    assert v_det is not None and v_det >= 1.0
+
+    v_int = REGISTRY.get_sample_value(
+        "pattern_intent_total", {"market": market, "pattern": pattern, "side": side}
+    )
+    assert v_int is not None and v_int >= 1.0
+
+    # Histogram observed with positive value
+    v_cnt = REGISTRY.get_sample_value("pattern_to_intent_latency_seconds_count")
+    v_sum = REGISTRY.get_sample_value("pattern_to_intent_latency_seconds_sum")
+    assert v_cnt is not None and v_cnt >= 1.0
+    assert v_sum is not None and v_sum > 0.0
+


### PR DESCRIPTION
## Summary
Introduce lightweight, strategy-agnostic observability for candlestick pattern events. Adds Prometheus counters/histogram, Loki-structured logs, Grafana panels, a simple alert, and an ENV-gated synthetic emitter to validate locally without depending on unmerged strategy code.

## Changes
- Metrics (src/paperbot/metrics/exec.py)
  - Counter: `pattern_detected_total{market,symbol,pattern}`
  - Counter: `pattern_intent_total{market,pattern,side}`
  - Histogram: `pattern_to_intent_latency_seconds` with buckets `[0.5,1,2,5,10,30,60]`
  - Helpers: `inc_pattern_detected`, `inc_pattern_intent`, `observe_pattern_to_intent_latency`
- Structured logs (src/paperbot/logs/decision_log.py)
  - `log_pattern_event(event_type, market, symbol, pattern, rsi=None, side=None, ts=None, extra=None)`
  - Emits JSON for Loki with keys: `event`, `market`, `symbol`, `pattern`, `rsi`, `side`, `ts`, `severity`, `component`, `schema_version`.
- Strategy wiring points (src/paperbot/strategies/runner.py)
  - `record_pattern_detected(...)` and `record_pattern_intent(...)` (no dependency on specific strategies)
- Demo emitter (src/paperbot/main.py)
  - ENV-gated: `ENABLE_PATTERN_OBS_DEMO=1`; interval `PATTERN_OBS_DEMO_SECONDS` (default 15)
  - Emits BTC/USDT `pattern_detected` (bullish_engulfing, rsi=33) then `pattern_intent` (long) after ~0.5s
- Grafana (config/grafana/provisioning/dashboards/paperbot.json)
  - New row “Patterns”: detections rate, intents rate, latency P50/P95, Loki logs panels
- Alert (config/grafana/provisioning/alerting/patterns-min-activity.yml)
  - If `sum(increase(pattern_detected_total[30m])) == 0` for 45m → “No pattern detections (30m)”
  - Datasource UID: `PBFA97CFB590B2093`
- Docs
  - ADR: `docs/decisions/ADR-0012-pattern-observability.md`
  - Runbook: new section “Pattern Observability (Phase 2.5)”
  - README: features bullet linking to ADR + Runbook
  - .env example: `src/paperbot/.env.example`
- Tooling
  - Smoke script: `scripts/smoke_pattern_obs.sh`
- Tests
  - `tests/test_pattern_observability.py` covering counters/logs/histogram

## How to Run
- Compose (Prometheus+Grafana):
  - `ENABLE_PATTERN_OBS_DEMO=1 PATTERN_OBS_DEMO_SECONDS=10 docker compose up`
- Validate metrics:
  - `curl -s http://localhost:8000/metrics | egrep 'pattern_detected_total|pattern_intent_total|pattern_to_intent_latency_seconds_bucket'`
- Grafana → Paperbot Overview → Patterns row
  - P50: `histogram_quantile(0.5, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
  - P95: `histogram_quantile(0.95, sum by (le) (rate(pattern_to_intent_latency_seconds_bucket[5m])))`
- Loki (optional overlay `-f docker-compose.loki.yml`):
  - `{app="paperbot"} |= "pattern_detected"`
  - `{app="paperbot"} |= "pattern_intent"`
  - Note: If you prefer JSON filtering and your Loki supports it, use
    `{app="paperbot"} | json | event == "pattern_detected"` (and `pattern_intent`).

## Compatibility
- Additive; no changes to existing strategy/execution flows.
- Metrics use safe getters; tolerant in constrained envs and tests.

## Checklist
- [x] Metrics compile and export
- [x] Logs JSON parse in Grafana Loki
- [x] Panels present under “Patterns”
- [x] Alert provisioned
- [x] Smoke and unit tests present

## Links
- ADR: `docs/decisions/ADR-0012-pattern-observability.md`
- Runbook: `docs/RUNBOOK.md#pattern-observability-phase-25`
